### PR TITLE
Correctly propagate N_CONTEXT and N_CORE

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -49,8 +49,8 @@ packages:
     - redundancy_cells
     - register_interface
   hwpe-ctrl:
-    revision: 3690a3c648f120546d8de2bc583d5170c36d2f20
-    version: 2.0.0
+    revision: 4977b6cf42b96f3fefd1973281d5c4b8259c50d5
+    version: null
     source:
       Git: https://github.com/pulp-platform/hwpe-ctrl.git
     dependencies:

--- a/Bender.yml
+++ b/Bender.yml
@@ -7,7 +7,7 @@ package:
 dependencies:
   hwpe-stream: { git: "https://github.com/pulp-platform/hwpe-stream.git", rev: 40ab0fe1433dc080a49aa1926ce09df9ab3f5fb5 } # branch: prasadar/multi-precision
   hci:         { git: "https://github.com/pulp-platform/hci.git", rev: 9844a893c34612ac66697e8dcd60214296f2634c } # branch: prasadar/multi-precision
-  hwpe-ctrl:   { git: "https://github.com/pulp-platform/hwpe-ctrl.git", version: 2.0 }
+  hwpe-ctrl:   { git: "https://github.com/pulp-platform/hwpe-ctrl.git", rev: 4977b6cf42b96f3fefd1973281d5c4b8259c50d5 } # branch: master
 
 
 sources:

--- a/rtl/datamover_top.sv
+++ b/rtl/datamover_top.sv
@@ -28,7 +28,7 @@ module datamover_top
   parameter int unsigned NUM_ELEM_WORD = 4,       // number of elements in a memory bank word
   parameter int unsigned ELEM_WIDTH = 8,          // element width (in bits)
   parameter int unsigned N_CORES   = 8,           // number of cores for event inputs
-  parameter int unsigned N_CONTEXT = 2,           // number of context for control slave regfile
+  parameter int unsigned N_CONTEXT = 4,           // number of context for control slave regfile
   parameter int unsigned MISALIGNED_ACCESSES = 0, // enable misaligned accesses on TCDM interface
   parameter hci_size_parameter_t `HCI_SIZE_PARAM(tcdm) = '0,
   // Dependent parameters: do not modify!
@@ -138,12 +138,16 @@ module datamover_top
   );
   
   // The slave module exposes a peripheral interconnect HWPE-Periph plug;
-  // in the default configuration, it provides 2 contexts with 13 registers
+  // in the default configuration, it provides 4 contexts with 11 registers
   // each, which are exposed into `reg_file.hwpe_params`
+
+  // Previously it was 2 contexts with 13 registers: since the datamover is used for relatively
+  // fine-grained jobs, the new config makes offloading faster by compacting the LEN registers
+  // and allows for more contexts
   hwpe_ctrl_slave #(
     .REGFILE_SCM    ( 0  ),
-    .N_CORES        ( 8  ),
-    .N_CONTEXT      ( 4  ),
+    .N_CORES        ( N_CORES   ),
+    .N_CONTEXT      ( N_CONTEXT ),
     .N_IO_REGS      ( 11 ),
     .N_GENERIC_REGS ( 8  ),
     .ID_WIDTH       ( ID )
@@ -247,7 +251,7 @@ module datamover_top
 
   // Bind the output event, which is propagated to the event unit and used
   // to implement HWPE datamover barriers.
-  assign evt_o = slave_flags.evt[7:0];
+  assign evt_o = slave_flags.evt[N_CORES-1:0];
 
 
   localparam int unsigned DEBUG_DW  = `HCI_SIZE_GET_DW(tcdm);


### PR DESCRIPTION
- Correctly propagate N_CONTEXT and N_CORE
- Bump to HWPE Ctrl version fixing the unwanted combinational reads in the FF regfile